### PR TITLE
🔒 [security fix: Remove hardcoded Telegram credentials]

### DIFF
--- a/Bots_XML/B/Binary V5 Expert pro (1) (1).xml
+++ b/Bots_XML/B/Binary V5 Expert pro (1) (1).xml
@@ -681,12 +681,12 @@
                           <block type="notify_telegram" id=":L;o$/S0X^2^nt%taS5}" collapsed="true">
                             <value name="TELEGRAM_ACCESS_TOKEN">
                               <shadow type="text" id="g2ZFbD2wcT+a0m~Pc+S_">
-                                <field name="TEXT">6274362984:AAHxEunMiwQXaohhi-5VwjAmbi-1TZLGdAw</field>
+                                <field name="TEXT">YOUR_TELEGRAM_TOKEN</field>
                               </shadow>
                             </value>
                             <value name="TELEGRAM_CHAT_ID">
                               <shadow type="text" id="pW*htCwp.IBKH@{W!4+0">
-                                <field name="TEXT">5622115596</field>
+                                <field name="TEXT">YOUR_TELEGRAM_CHAT_ID</field>
                               </shadow>
                             </value>
                             <value name="TELEGRAM_MESSAGE">
@@ -807,12 +807,12 @@
                           <block type="notify_telegram" id="yq6!3Zf3EcgcIt5917lV" collapsed="true">
                             <value name="TELEGRAM_ACCESS_TOKEN">
                               <shadow type="text" id="q?EK7#5nAVkzk8!#];ga">
-                                <field name="TEXT">6274362984:AAHxEunMiwQXaohhi-5VwjAmbi-1TZLGdAw</field>
+                                <field name="TEXT">YOUR_TELEGRAM_TOKEN</field>
                               </shadow>
                             </value>
                             <value name="TELEGRAM_CHAT_ID">
                               <shadow type="text" id="@kF^^~~.G*{KQ?+^(Q*~">
-                                <field name="TEXT">5622115596</field>
+                                <field name="TEXT">YOUR_TELEGRAM_CHAT_ID</field>
                               </shadow>
                             </value>
                             <value name="TELEGRAM_MESSAGE">


### PR DESCRIPTION


The modification was verified to ensure the XML file remains well-formed.

Summary of changes:
- Located all instances of the hardcoded token and chat ID.
- Replaced them with standardized placeholders.
- Verified XML integrity using `xml.etree.ElementTree`.

---
*PR created automatically by Jules for task [11728470668649455886](https://jules.google.com/task/11728470668649455886) started by @alanvito1*